### PR TITLE
Fix serialisation of Namelist objects by converting to dict type

### DIFF
--- a/run_summary.py
+++ b/run_summary.py
@@ -42,6 +42,8 @@ import nmltab  # from https://github.com/aekiss/nmltab
 import warnings
 warnings.simplefilter('ignore', np.RankWarning)
 
+yaml.add_representer(OrderedDict, lambda dumper, data: dumper.represent_mapping('tag:yaml.org,2002:map', data.items()))
+
 
 def num(s):
     """
@@ -458,7 +460,7 @@ def parse_nml(paths):
         for fname in fnames:
             if os.path.isfile(fname):  # no accessom2.nml for non-YATM run
                 parsed_items[fname.split(path)[1].strip('/')] \
-                        = f90nml.read(fname)
+                        = f90nml.read(fname).todict()
     return parsed_items
 
 


### PR DESCRIPTION
Closes #24 

If run with `--no-stats` option works fine with no errors:
```
$ python run_summary.py -d --no_stats /home/502/aph502/payu/access-om2/1deg_jra55_ryf
Generating run summary of /home/502/aph502/payu/access-om2/1deg_jra55_ryf...........
Writing run_summary_home_502_aph502_payu_access-om2_1deg_jra55_ryf.yaml

Writing run_summary_home_502_aph502_payu_access-om2_1deg_jra55_ryf.csv
Done.
$
```

If run without the option (so calculating stats) there are a bunch of warnings:
```python
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/lib/function_base.py:2853: RuntimeWarning: invalid value encountered in divide
  c /= stddev[:, None]
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/lib/function_base.py:2854: RuntimeWarning: invalid value encountered in divide
  c /= stddev[None, :]
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:164: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  arr = asanyarray(a)
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/lib/function_base.py:3700: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  a = np.asanyarray(a)
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:198: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  arr = asanyarray(a)
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/lib/function_base.py:2615: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  m = np.asarray(m)
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/lib/polynomial.py:629: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  x = NX.asarray(x) + 0.0
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/fromnumeric.py:3432: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:190: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:265: RuntimeWarning: Degrees of freedom <= 0 for slice
  ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:223: RuntimeWarning: invalid value encountered in divide
  arrmean = um.true_divide(arrmean, div, out=arrmean, casting='unsafe',
/g/data3/hh5/public/apps/miniconda3/envs/analysis3-23.04/lib/python3.9/site-packages/numpy/core/_methods.py:257: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)
```

But the warnings are exactly the same without the code change, so I don't think it has created any new problems.